### PR TITLE
allow higher major version

### DIFF
--- a/lib/checkCommands.js
+++ b/lib/checkCommands.js
@@ -16,7 +16,7 @@ const checkDockerVersion = (callback) => {
       const major = parseInt(versArray[0], 10);
       const minor = parseInt(versArray[1], 10);
       // const micro = parseInt(versArray[2], 10);
-      if (major >= minX && minor >= minY) {
+      if (major > minX || (major == minX && minor >= minY)) {
         callback();
       } else {
         console.log(chalk.red(`Please upgrade the version of Docker. We need version higher than ${minX}.${minY}.*.`));
@@ -84,7 +84,7 @@ const checkOpenshiftVersion = (callback) => {
       }
       const major = parseInt(version[1], 10);
       const minor = parseInt(version[2], 10);
-      if (major >= minX && minor >= minY) {
+      if (major > minX || (major == minX && minor >= minY)) {
         child.kill();
         callback();
       } else {


### PR DESCRIPTION
If a dependency's major version increases, the minor version will tend to restart at 0.

This code does not handle this case

(on the mac, for some reason, they upgraded the docker version all the way up to 17)