### PR TITLE
Changes docker-compose file extension to yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ Later, you can find your hawkular-services listening on http://localhost:8080
 Running 'docker-compose up --force-recreate' in directory: /tmp/tmp-11573k3ujXFLACh9z
 ```
 
-If you navigate to `/tmp/tmp-11573k3ujXFLACh9z`, you can run `docker-dompose up` to start it again. This is not a standard use-case, though. Any other `docker-compose` command works just fine. So for instance you may want to see only the Cassandra logs by `docker-compose logs -f myCassandra` or inspecting the Hawkular Services container by `docker-compose exec hawkular /bin/bash`, etc. Also, nothing protects you from editing the `docker-compose.yaml` file that was created in that tmp directory.
+If you navigate to `/tmp/tmp-11573k3ujXFLACh9z`, you can run `docker-dompose up` to start it again. This is not a standard use-case, though. Any other `docker-compose` command works just fine. So for instance you may want to see only the Cassandra logs by `docker-compose logs -f myCassandra` or inspecting the Hawkular Services container by `docker-compose exec hawkular /bin/bash`, etc. Also, nothing protects you from editing the `docker-compose.yml` file that was created in that tmp directory.
 

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -92,7 +92,7 @@ const runDockerCompose = (answers, timeout) => {
       if (err) {
         throw err;
       }
-      fs.writeFileSync(`${directory}/docker-compose.yaml`, result);
+      fs.writeFileSync(`${directory}/docker-compose.yml`, result);
       setTimeout(() => {
         status.stop();
         runItInternal(answers, directory, timeout);


### PR DESCRIPTION
This fixes the following warning, making it more future-proof:

```
WARNING: Please be aware that .yml is the expected extension in most
cases, and using .yaml can cause compatibility issues in future.
```