### PR TITLE
Standalone service is always hawkfly on docker-compose files

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -57,8 +57,7 @@ const runItInternal = (answers, directory, timeout) => {
   try {
     if (answers.wfType === 'Standalone') {
       if (answers.wfStandaloneCount > 1) {
-        const template = answers.hawkAgent === 'javaAgent' ? 'hawkfly-new' : 'hawkfly-old';
-        dc.scale(directory, template, answers.wfStandaloneCount);
+        dc.scale(directory, 'hawkfly', answers.wfStandaloneCount);
       }
     } else if (answers.wfType === 'Domain') {
       if (answers.hostControllerCount > 2) {


### PR DESCRIPTION
This command silently failed because of the ~~timeout~~ asynchronous call in `dc.scale`.