### PR TITLE
Allow mutable wfly servers

### DIFF
--- a/lib/configs/standalone/hawkfly-new.mustache
+++ b/lib/configs/standalone/hawkfly-new.mustache
@@ -1,29 +1,31 @@
-# set up the wildfly with embedded hawkular-agent
-hawkfly:
-  image: "hawkular/wildfly-hawkular-javaagent:{{wfStandaloneVersion}}"
-  #ports:
-  #  - "8081:8080"
-  links:
-    - hawkular
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the wildfly with embedded hawkular-agent
+  hawkfly:
+    image: "hawkular/wildfly-hawkular-javaagent:{{wfStandaloneVersion}}"
+    #ports:
+    #  - "8081:8080"
+    links:
+      - hawkular
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/configs/standalone/hawkfly-old.mustache
+++ b/lib/configs/standalone/hawkfly-old.mustache
@@ -1,29 +1,31 @@
-# set up the wildfly with embedded hawkular-agent
-hawkfly:
-  image: "pilhuhn/hawkfly:{{wfStandaloneVersion}}"
-  #ports:
-  #  - "8081:8080"
-  links:
-    - hawkular
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the wildfly with embedded hawkular-agent
+  hawkfly:
+    image: "pilhuhn/hawkfly:{{wfStandaloneVersion}}"
+    #ports:
+    #  - "8081:8080"
+    links:
+      - hawkular
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/configs/standalone/hservices.mustache
+++ b/lib/configs/standalone/hservices.mustache
@@ -1,23 +1,25 @@
-# set up the hawkular services only
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the hawkular services only
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/dockerCompose.js
+++ b/lib/dockerCompose.js
@@ -3,8 +3,9 @@
 const execSync = require('child_process').execSync;
 const exec = require('child_process').exec;
 const chalk = require('chalk');
+const parseKeyValue = require('parse-key-value');
 
-const runCommand = (command, path, asynchronous) => {
+const runCommand = (command, path, asynchronous, customOptions) => {
   const options = {
     cwd: path,
     killSignal: 'SIGTERM',
@@ -12,20 +13,34 @@ const runCommand = (command, path, asynchronous) => {
     maxBuffer: 10 * 1024 * 1024,
     stdio: ['inherit', 'inherit', 'inherit']
   };
+  if (customOptions) {
+    Object.assign(options, customOptions);
+  }
   console.log(chalk.cyan(`Running '${command}' in directory: ${path}`));
   const executable = asynchronous ? exec : execSync;
   const dc = executable(command, options);
-  dc && dc.stdout.on('data', (data) => {
+  dc && dc.stdout && dc.stdout.on('data', (data) => {
     data && console.log(`${data}`);
   });
-  dc && dc.stderr.on('data', (data) => {
+  dc && dc.stderr && dc.stderr.on('data', (data) => {
     data && console.log(`stderr: ${data}`);
   });
   return dc;
 };
 
 const dockerComposeUp = (path, asynchronous) =>
-  runCommand('docker-compose up --force-recreate', path, asynchronous);
+  runCommand('docker-compose up', path, asynchronous);
+
+const dockerComposeCreate = (path, forceRecreate, service, asynchronous) => {
+  const serviceName = service === undefined ? '' : service;
+  const forceRecreateFlag = forceRecreate ? '--force-recreate' : '';
+  runCommand(`docker-compose create ${forceRecreateFlag} ${serviceName}`, path, asynchronous);
+};
+
+const dockerComposeStop = (path, service, asynchronous) => {
+  const serviceName = service === undefined ? '' : service;
+  runCommand(`docker-compose stop ${serviceName}`, path, asynchronous);
+};
 
 const dockerComposeRm = (path, timeout) => {
   if (timeout > 0) {
@@ -42,6 +57,16 @@ const dockerComposeKill = (path, timeout) => {
   } else {
     runCommand('docker-compose rm --force --all', path, false);
   }
+};
+
+const dockerComposePs = (path, service) => {
+  const output = runCommand(
+    `docker-compose ps -q ${service}`,
+    path,
+    false,
+    { stdio: ['inherit', 'pipe', 'inherit'] }
+  );
+  return output.toString().trim().split(/\r?\n/);
 };
 
 const openshiftKill = (timeout) => {
@@ -65,12 +90,28 @@ const dockerKillAllCassandraNodes = (version) => {
   return runCommand(cmd, '.', true);
 };
 
+const dockerEnvironmentVariables = (container) => {
+  const command = `docker inspect \
+  --format='{{range $index, $value := .Config.Env}}{{if $index}};{{$value}}{{end}}{{end}}' ${container}`;
+  const output = runCommand(command, '/', false, { stdio: ['inherit', 'pipe', 'inherit'] });
+  return parseKeyValue(output);
+};
+
+const dockerCp = (source, destination) => {
+  runCommand(`docker cp ${source} ${destination}`);
+};
+
 const dockerComposeScale = (path, service, instances) =>
-  runCommand(`sleep 7 && docker-compose scale ${service}=${instances}`, path, true);
+  runCommand(`docker-compose scale ${service}=${instances}`, path, false);
 
 module.exports = {
   up: dockerComposeUp,
+  create: dockerComposeCreate,
+  stop: dockerComposeStop,
   rm: dockerComposeRm,
+  ps: dockerComposePs,
+  cp: dockerCp,
+  env: dockerEnvironmentVariables,
   kill: dockerComposeKill,
   scale: dockerComposeScale,
   runCassandra: dockerRunCassandraNode,

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -7,10 +7,12 @@ const CLI = require('clui');
 const constants = require('./constants');
 const execSync = require('child_process').execSync;
 const fs = require('fs');
+const jsonTransform = require('./jsonTransform');
 const mustache = require('mustache');
 const osUtils = require('./osUtils');
 const path = require('path');
 const tmp = require('tmp');
+const yaml = require('js-yaml');
 
 const Spinner = CLI.Spinner;
 
@@ -25,6 +27,32 @@ const sayWhereItIsRunning = (answers) => {
    chalk.green(answers.hawkularUsername));
   const greenPass = chalk.green(answers.hawkularPassword);
   console.log(`${chalk.grey('   Password: ')}${greenPass}\n\n`);
+};
+
+const updateWfAgentConfiguration = (updateSteps, directory, containers) => {
+  for (let i = 0; i < containers.length; i += 1) {
+    const container = containers[i];
+    const environment = dc.env(container);
+    const configurationName = 'hawkular-javaagent-config.yaml';
+    const containerConfigPath = `${container}:${environment.JBOSS_HOME}/standalone/configuration/${configurationName}`;
+    const localConfigPath = `${directory}/${container}_${configurationName}`;
+    dc.cp(containerConfigPath, localConfigPath);
+    let config = yaml.safeLoad(fs.readFileSync(localConfigPath));
+    config = jsonTransform(config, updateSteps);
+    fs.writeFileSync(localConfigPath, yaml.safeDump(config));
+    dc.cp(localConfigPath, containerConfigPath);
+  }
+};
+
+const buildWfAgentConfigurationUpdateSteps = (answers) => {
+  const updateSteps = [];
+  if (answers.wfType === 'Standalone' && answers.wildflyImmutableAgent === false) {
+    updateSteps.push({
+      path: ['subsystem', 'immutable'],
+      value: 'false'
+    });
+  }
+  return updateSteps;
 };
 
 const runItInternal = (answers, directory, timeout) => {
@@ -74,11 +102,21 @@ const runItInternal = (answers, directory, timeout) => {
         dc.scale(directory, domainScenarioServiceMapping(answers.domainScenario), answers.hostControllerCount - 1);
       }
     }
-
     sayWhereItIsRunning(answers);
+
+    dc.create(directory, true);
+
+    const wfAgentConfigurationUpdateSteps = buildWfAgentConfigurationUpdateSteps(answers);
+
+    if (wfAgentConfigurationUpdateSteps.length > 0) {
+      dc.stop(directory);
+      const wfContainerIds = dc.ps(directory, 'hawkfly');
+      updateWfAgentConfiguration(wfAgentConfigurationUpdateSteps, directory, wfContainerIds);
+    }
 
     // finally run it!
     dc.up(directory);
+
     process.exit();
   } catch (e) {
     console.log(chalk.blue('\nStopping Hawkinit.\n'));
@@ -229,6 +267,9 @@ const postProcessAnswers = (answers) => {
   }
   if (clone.defaultCredentials === undefined) {
     clone.defaultCredentials = true;
+  }
+  if (clone.wildflyImmutableAgent === undefined) {
+    clone.wildflyImmutableAgent = true;
   }
 
   // sort by keys

--- a/lib/jsonTransform.js
+++ b/lib/jsonTransform.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const objectPath = require('object-path');
+
+/**
+* Transform properties of objects with a given template.
+* Given object:
+* { "a" : { "b" : "c" } }
+* the template:
+* [ { "path" : ["a", "b"], "value" : "d" } ]
+* yields:
+* { "a" : { "b" : "d" } }
+*
+* Note that we could have used '"path" : "a.b"' but there is
+*  ambiguity since we could be reffering to a property named "a.b".
+*/
+const transform = (object, template) => {
+  const clone = Object.assign({}, object);
+  for (let i = 0; i < template.length; i += 1) {
+    const rule = template[i];
+    objectPath.set(clone, rule.path, rule.value);
+  }
+  return clone;
+};
+
+module.exports = transform;

--- a/lib/wizzard.js
+++ b/lib/wizzard.js
@@ -161,6 +161,13 @@ const show = (save, timeout, full) => {
       when: answers => answers.wfType === 'Standalone' && answers.hawkflyWfEap === 'EAP'
     },
     {
+      type: 'confirm',
+      name: 'wildflyImmutableAgent',
+      message: 'Do you want your standalone WF (wildfly-hawkular-javaagent) to use an immutable agent?',
+      default: true,
+      when: answers => !answers.hawkAgent || answers.hawkAgent === 'javaAgent'
+    },
+    {
       type: 'input',
       name: 'wfStandaloneCount',
       message: 'How many standalone servers do you want to spawn?',

--- a/package.json
+++ b/package.json
@@ -39,8 +39,11 @@
     "command-line-usage": "^3.0.8",
     "figlet": "^1.2.0",
     "inquirer": "^1.2.3",
+    "js-yaml": "^3.8.3",
     "lodash": "^4.17.2",
     "mustache": "^2.3.0",
+    "object-path": "^0.11.4",
+    "parse-key-value": "^1.0.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
This is done by 
1. Creating the containers (without starting).
2. Copying the hawkular-javaagent-configuration.yaml from WF container and setting subsystem.immutable = false
3. Putting back the configuration file.

I also had to update the docker-compose.yaml version of the standalone servers to `2`. There were some network issues when stopping/creating containers that were solved this way.

@Jiri-Kremser Could you please take a look? 
Other alternatives that i could think to this would be to actually create a new image on the fly with the immutable=false.

Note: This option only appears with the -f flag and when using hawkular-javaagent.