### PR TITLE
Allow mutable wfly servers by building a new image

### DIFF
--- a/lib/configs/standalone/hawkfly-new.mustache
+++ b/lib/configs/standalone/hawkfly-new.mustache
@@ -1,29 +1,31 @@
-# set up the wildfly with embedded hawkular-agent
-hawkfly:
-  image: "hawkular/wildfly-hawkular-javaagent:{{wfStandaloneVersion}}"
-  #ports:
-  #  - "8081:8080"
-  links:
-    - hawkular
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the wildfly with embedded hawkular-agent
+  hawkfly:
+    image: "hawkular/wildfly-hawkular-javaagent:{{wfStandaloneVersion}}"
+    #ports:
+    #  - "8081:8080"
+    links:
+      - hawkular
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/configs/standalone/hawkfly-old.mustache
+++ b/lib/configs/standalone/hawkfly-old.mustache
@@ -1,29 +1,31 @@
-# set up the wildfly with embedded hawkular-agent
-hawkfly:
-  image: "pilhuhn/hawkfly:{{wfStandaloneVersion}}"
-  #ports:
-  #  - "8081:8080"
-  links:
-    - hawkular
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the wildfly with embedded hawkular-agent
+  hawkfly:
+    image: "pilhuhn/hawkfly:{{wfStandaloneVersion}}"
+    #ports:
+    #  - "8081:8080"
+    links:
+      - hawkular
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/configs/standalone/hservices.mustache
+++ b/lib/configs/standalone/hservices.mustache
@@ -1,23 +1,25 @@
-# set up the hawkular services only
-# The hawkular-server
-hawkular:
-  image: "hawkular/hawkular-services:{{hawkVersion}}"
-  ports:
-    - "8080:8080"
-    - "8443:8443"
-    - "9990:9990"
-  links:
-    - myCassandra
-  volumes:
-    - /tmp/opt/hawkular:/opt/data
-  environment:
-    - HAWKULAR_BACKEND=remote
-    - CASSANDRA_NODES=myCassandra
-    - HAWKULAR_USER={{hawkularUsername}}
-    - HAWKULAR_PASSWORD={{hawkularPassword}}
-    - HAWKULAR_USE_SSL={{ssl}}
-# The used Cassandra container
-myCassandra:
-  image: cassandra:{{cassandraVersion}}
-  environment:
-    - CASSANDRA_START_RPC=true
+version: '2'
+services:
+  # set up the hawkular services only
+  # The hawkular-server
+  hawkular:
+    image: "hawkular/hawkular-services:{{hawkVersion}}"
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+    links:
+      - myCassandra
+    volumes:
+      - /tmp/opt/hawkular:/opt/data
+    environment:
+      - HAWKULAR_BACKEND=remote
+      - CASSANDRA_NODES=myCassandra
+      - HAWKULAR_USER={{hawkularUsername}}
+      - HAWKULAR_PASSWORD={{hawkularPassword}}
+      - HAWKULAR_USE_SSL={{ssl}}
+  # The used Cassandra container
+  myCassandra:
+    image: cassandra:{{cassandraVersion}}
+    environment:
+      - CASSANDRA_START_RPC=true

--- a/lib/dockerCompose.js
+++ b/lib/dockerCompose.js
@@ -3,8 +3,9 @@
 const execSync = require('child_process').execSync;
 const exec = require('child_process').exec;
 const chalk = require('chalk');
+const parseKeyValue = require('parse-key-value');
 
-const runCommand = (command, path, asynchronous) => {
+const runCommand = (command, path, asynchronous, customOptions) => {
   const options = {
     cwd: path,
     killSignal: 'SIGTERM',
@@ -12,13 +13,16 @@ const runCommand = (command, path, asynchronous) => {
     maxBuffer: 10 * 1024 * 1024,
     stdio: ['inherit', 'inherit', 'inherit']
   };
+  if (customOptions) {
+    Object.assign(options, customOptions);
+  }
   console.log(chalk.cyan(`Running '${command}' in directory: ${path}`));
   const executable = asynchronous ? exec : execSync;
   const dc = executable(command, options);
-  dc && dc.stdout.on('data', (data) => {
+  dc && dc.stdout && dc.stdout.on('data', (data) => {
     data && console.log(`${data}`);
   });
-  dc && dc.stderr.on('data', (data) => {
+  dc && dc.stderr && dc.stderr.on('data', (data) => {
     data && console.log(`stderr: ${data}`);
   });
   return dc;
@@ -44,6 +48,16 @@ const dockerComposeKill = (path, timeout) => {
   }
 };
 
+const dockerComposePs = (path, service) => {
+  const output = runCommand(
+    `docker-compose ps -q ${service}`,
+    path,
+    false,
+    { stdio: ['inherit', 'pipe', 'inherit'] }
+  );
+  return output.toString().trim().split(/\r?\n/);
+};
+
 const openshiftKill = (timeout) => {
   if (timeout > 0) {
     runCommand(`sleep ${timeout} && oc cluster down`, null, true);
@@ -65,12 +79,44 @@ const dockerKillAllCassandraNodes = (version) => {
   return runCommand(cmd, '.', true);
 };
 
+const dockerEnvironmentVariables = (container) => {
+  const command = `docker inspect \
+  --format='{{range $index, $value := .Config.Env}}{{if $index}};{{$value}}{{end}}{{end}}' ${container}`;
+  const output = runCommand(command, '/', false, { stdio: ['inherit', 'pipe', 'inherit'] });
+  return parseKeyValue(output);
+};
+
+const dockerCreate = (path, image) => {
+  const output = runCommand(
+    `docker create ${image}`,
+    path,
+    false,
+    { stdio: ['inherit', 'pipe', 'inherit'] }
+  );
+  return output.toString().trim();
+};
+
+const dockerRm = container =>
+  runCommand(`docker rm -f ${container}`, '.');
+
+const dockerCopy = (source, destination) =>
+  runCommand(`docker cp ${source} ${destination}`, '.');
+
+const dockerBuild = (path, image) =>
+  runCommand(`docker build --pull=true -t ${image} .`, path);
+
 const dockerComposeScale = (path, service, instances) =>
   runCommand(`sleep 7 && docker-compose scale ${service}=${instances}`, path, true);
 
 module.exports = {
   up: dockerComposeUp,
+  create: dockerCreate,
   rm: dockerComposeRm,
+  ps: dockerComposePs,
+  cp: dockerCopy,
+  removeContainer: dockerRm,
+  build: dockerBuild,
+  env: dockerEnvironmentVariables,
   kill: dockerComposeKill,
   scale: dockerComposeScale,
   runCassandra: dockerRunCassandraNode,

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -7,10 +7,13 @@ const CLI = require('clui');
 const constants = require('./constants');
 const execSync = require('child_process').execSync;
 const fs = require('fs');
+const hash = require('object-hash');
+const jsonTransform = require('./jsonTransform');
 const mustache = require('mustache');
 const osUtils = require('./osUtils');
 const path = require('path');
 const tmp = require('tmp');
+const yaml = require('js-yaml');
 
 const Spinner = CLI.Spinner;
 
@@ -27,6 +30,45 @@ const sayWhereItIsRunning = (answers) => {
   console.log(`${chalk.grey('   Password: ')}${greenPass}\n\n`);
 };
 
+const buildWfAgentConfigurationUpdateSteps = (answers) => {
+  const updateSteps = [];
+  if (answers.wfType === 'Standalone' && answers.wildflyImmutableAgent === false) {
+    updateSteps.push({
+      path: ['subsystem', 'immutable'],
+      value: 'false'
+    });
+  }
+  return updateSteps;
+};
+
+const buildWfAgentCustomImage = (directory, updateSteps) => {
+  const configurationName = 'hawkular-javaagent-config.yaml';
+  const resultImage = `hawkinit/hawkfly:${hash(updateSteps)}`;
+  const dockerComposePath = path.join(directory, 'docker-compose.yml');
+  const dockerCompose = yaml.safeLoad(fs.readFileSync(dockerComposePath));
+  const hawkflyDockerDir = tmp.dirSync({ dir: directory, prefix: 'hawkfly_docker_' }).name;
+  const oldImage = dockerCompose.services.hawkfly.image;
+  const container = dc.create(directory, oldImage);
+  const env = dc.env(container);
+  const containerConfigPath = `${env.JBOSS_HOME}/standalone/configuration/${configurationName}`;
+  const localConfigPath = path.join(hawkflyDockerDir, configurationName);
+
+  dc.cp(`${container}:${containerConfigPath}`, localConfigPath);
+  dc.removeContainer(container);
+  let config = yaml.safeLoad(fs.readFileSync(localConfigPath));
+  config = jsonTransform(config, updateSteps);
+  fs.writeFileSync(localConfigPath, yaml.safeDump(config));
+
+  fs.writeFileSync(path.join(hawkflyDockerDir, 'Dockerfile'), Buffer([
+    `FROM ${oldImage}`,
+    `COPY ${configurationName} ${containerConfigPath}`
+  ].join('\n').concat('\n')));
+
+  dc.build(hawkflyDockerDir, `${resultImage}`);
+  dockerCompose.services.hawkfly.image = resultImage;
+  fs.writeFileSync(dockerComposePath, yaml.safeDump(dockerCompose));
+};
+
 const runItInternal = (answers, directory, timeout) => {
   if (timeout) {
     const seconds = timeout * 60;
@@ -40,6 +82,13 @@ const runItInternal = (answers, directory, timeout) => {
     console.log(chalk.cyan('Removing containers created by docker-compose script.'));
     dc.rm(directory, 0);
   });
+
+  // Check if we need custom settings
+  const wfAgentConfigurationUpdateSteps = buildWfAgentConfigurationUpdateSteps(answers);
+
+  if (wfAgentConfigurationUpdateSteps.length > 0) {
+    buildWfAgentCustomImage(directory, wfAgentConfigurationUpdateSteps);
+  }
 
   // run additional cassandra nodes if reqested
   if (answers.cassandraCount > 1) {
@@ -229,6 +278,9 @@ const postProcessAnswers = (answers) => {
   }
   if (clone.defaultCredentials === undefined) {
     clone.defaultCredentials = true;
+  }
+  if (clone.wildflyImmutableAgent === undefined) {
+    clone.wildflyImmutableAgent = true;
   }
 
   // sort by keys

--- a/lib/jsonTransform.js
+++ b/lib/jsonTransform.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const objectPath = require('object-path');
+
+/**
+* Transform properties of objects with a given template.
+* Given object:
+* { "a" : { "b" : "c" } }
+* the template:
+* [ { "path" : ["a", "b"], "value" : "d" } ]
+* yields:
+* { "a" : { "b" : "d" } }
+*
+* Note that we could have used '"path" : "a.b"' but there is
+*  ambiguity since we could be reffering to a property named "a.b".
+*/
+const transform = (object, template) => {
+  const clone = Object.assign({}, object);
+  for (let i = 0; i < template.length; i += 1) {
+    const rule = template[i];
+    objectPath.set(clone, rule.path, rule.value);
+  }
+  return clone;
+};
+
+module.exports = transform;

--- a/lib/wizzard.js
+++ b/lib/wizzard.js
@@ -161,6 +161,13 @@ const show = (save, timeout, full) => {
       when: answers => answers.wfType === 'Standalone' && answers.hawkflyWfEap === 'EAP'
     },
     {
+      type: 'confirm',
+      name: 'wildflyImmutableAgent',
+      message: 'Do you want your standalone WF (wildfly-hawkular-javaagent) to use an immutable agent?',
+      default: true,
+      when: answers => !answers.hawkAgent || answers.hawkAgent === 'javaAgent'
+    },
+    {
       type: 'input',
       name: 'wfStandaloneCount',
       message: 'How many standalone servers do you want to spawn?',

--- a/package.json
+++ b/package.json
@@ -39,8 +39,12 @@
     "command-line-usage": "^3.0.8",
     "figlet": "^1.2.0",
     "inquirer": "^1.2.3",
+    "js-yaml": "^3.8.3",
     "lodash": "^4.17.2",
     "mustache": "^2.3.0",
+    "object-hash": "^1.1.8",
+    "object-path": "^0.11.4",
+    "parse-key-value": "^1.0.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
This is IMO a better approach than #29 but still similar.
The difference is that instead of modifying the current container, we create a new image off that container with the modifications.

In that way, we can use ´docker-compose up/down´ and still have the mutable agent (unlike the other approach). Plus is cleaner as I had to modify less of the current code.