### PR TITLE
Load services and hawkfly versions from dockerhub

### DIFF
--- a/lib/wizzard.js
+++ b/lib/wizzard.js
@@ -9,6 +9,7 @@ const engine = require('./engine');
 const fs = require('fs');
 const inquirer = require('inquirer');
 const path = require('path');
+const RestClient = require('node-rest-client').Client;
 const version = require('../package.json').version;
 
 const show = (save, timeout, full) => {
@@ -18,16 +19,36 @@ const show = (save, timeout, full) => {
     return valid || `Please enter a valid integer between 0 and ${maxValue}.`;
   };
 
+  // Based on this: https://gist.github.com/kizbitz/e59f95f7557b4bbb8bf2
+  const dockerHubLoadTags = (account, image, defaults) => {
+    const client = new RestClient();
+    return new Promise((resolve) => {
+      const fetchNext = (current, nextURL) => {
+        client.get(nextURL, (data) => {
+          for (let i = 0; i < data.results.length; i += 1) {
+            current.push(data.results[i].name);
+          }
+          if (data.next) {
+            fetchNext(current, data.next);
+          } else {
+            resolve(current);
+          }
+        }).on('error', () => {
+          resolve(defaults);
+        });
+      };
+      fetchNext([], `https://hub.docker.com/v2/repositories/${account}/${image}/tags/?page_size=10`);
+    });
+  };
+
   const hwkVersions = (framework) => {
     // checking if the oc or docker-compose are installed as a side effect
     if (check.orchestrationFrameworkValidator(framework)) {
-      return constants.HAWKULAR_VERSIONS;
+      return dockerHubLoadTags('hawkular', 'hawkular-services', constants.HAWKULAR_VERSIONS);
     }
     return [];
   };
 
-  // todo: get the tags dynamically https://gist.github.com/kizbitz/e59f95f7557b4bbb8bf2
-  // https://hub.docker.com/v2/repositories/hawkular/hawkular-services/tags/?page_size=10
   const questions = [
     {
       type: 'list',
@@ -139,7 +160,7 @@ const show = (save, timeout, full) => {
       name: 'wfStandaloneVersion',
       message: 'What version of instrumented standalone WF (hawkfly) do you want to run?',
       default: constants.HAWKFLY_VERSION_DEFAULT,
-      choices: constants.HAWKFLY_VERSIONS,
+      choices: () => dockerHubLoadTags('pilhuhn', 'hawkfly', constants.HAWKFLY_VERSIONS),
       when: answers => answers.wfType === 'Standalone' && answers.hawkAgent === 'Subsystem' &&
         (!answers.hawkflyWfEap || answers.hawkflyWfEap === 'WildFly')
     },
@@ -148,7 +169,7 @@ const show = (save, timeout, full) => {
       name: 'wfStandaloneVersion',
       message: 'What version of instrumented standalone WF (wildfly-hawkular-javaagent) do you want to run?',
       default: constants.HAWKFLY_NEW_VERSION_DEFAULT,
-      choices: constants.HAWKFLY_NEW_VERSIONS,
+      choices: () => dockerHubLoadTags('hawkular', 'wildfly-hawkular-javaagent', constants.HAWKFLY_NEW_VERSIONS),
       when: answers => answers.wfType === 'Standalone' && (!answers.hawkAgent || answers.hawkAgent === 'javaAgent') &&
         (!answers.hawkflyWfEap || answers.hawkflyWfEap === 'WildFly')
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "inquirer": "^1.2.3",
     "lodash": "^4.17.2",
     "mustache": "^2.3.0",
+    "node-rest-client": "^3.1.0",
     "tmp": "0.0.31"
   },
   "devDependencies": {


### PR DESCRIPTION
When trying to load the versions (hawkular, hawkfly) on the wizard, if any error pops, it fallback to defined constants.