### PR TITLE
Missing type conversion to String when checking versions of dependencies

### DIFF
--- a/lib/checkCommands.js
+++ b/lib/checkCommands.js
@@ -18,7 +18,7 @@ const checkDockerVersion = (callback) => {
   // after cut: '1.12.2,'
   child.stdout.on('data', (data) => {
     try {
-      const version = data.slice(0, -1);
+      const version = data.slice(0, -1).toString();
       const versArray = version.split('.');
       const major = parseInt(versArray[0], 10);
       const minor = parseInt(versArray[1], 10);
@@ -86,7 +86,7 @@ const checkDockerComposeVersion = (callback) => {
   // after cut: '1.13.0,'
   child.stdout.on('data', (data) => {
     try {
-      const version = data.slice(0, -1);
+      const version = data.slice(0, -1).toString();
       const versArray = version.split('.');
       const major = parseInt(versArray[0], 10);
       const minor = parseInt(versArray[1], 10);


### PR DESCRIPTION
`version` variable is not String typed. Then `version.split` is not a valid expression. 
It seems #slice method does not return a Buffer object.

This PR resolves the issue #41 